### PR TITLE
feat: add CI workflow for Python project and improve import structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: Python CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Install Poetry
+      run: |
+        pip install poetry
+
+    - name: Install dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pypoetry
+        key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-poetry-
+      run: poetry install
+
+    - name: Run lint and format check
+      run: |
+        poetry run task lint
+        poetry run task format --check
+
+
+    - name: Run tests with pytest
+      run: |
+        poetry run pytest tests/

--- a/src/cli/run_app.py
+++ b/src/cli/run_app.py
@@ -5,8 +5,7 @@ It imports necessary modules and renders the main pages of the application.
 
 import streamlit as st
 
-from pages import (estimate_page, freight_upload_page, train_validate_page,
-                   upload_page)
+from pages import estimate_page, freight_upload_page, train_validate_page, upload_page
 
 st.set_page_config(page_title="Packaging Cost Estimator", layout="wide")
 st.title("📦 Packaging Cost Estimator")

--- a/src/utils/lang.py
+++ b/src/utils/lang.py
@@ -1,6 +1,7 @@
 HUGGINGFACE_API_TOKEN = ""
 import streamlit as st
 import torch
+
 # 從 transformers 函式庫載入模型和分詞器
 from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
 


### PR DESCRIPTION
- Establishes a new workflow in `.github/workflows/ci.yml`.
- The workflow automatically runs on pushes and pull requests to the 'main' branch.
- Includes jobs for:
  - Setting up Python and Poetry environment.
  - Caching dependencies to speed up runs.
  - Running `lint` and `format --check`.
  - Executing tests with `pytest`.